### PR TITLE
Rearrange nodename and node ip ordered by nodes field spec defined by user.

### DIFF
--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -355,7 +355,7 @@ spec:
         - --enable-leader-election
         command:
         - /curve-operator
-        image: harbor.cloud.netease.com/curve/curve-operator:cd80cf5
+        image: harbor.cloud.netease.com/curve/curve-operator:52fcf5d
         name: manager
         resources:
           limits:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: harbor.cloud.netease.com/curve/curve-operator
   newName: harbor.cloud.netease.com/curve/curve-operator
-  newTag: cd80cf5
+  newTag: 52fcf5d

--- a/config/samples/operator_v1_curvecluster.yaml
+++ b/config/samples/operator_v1_curvecluster.yaml
@@ -9,10 +9,10 @@ spec:
     image: opencurvedocker/curvebs:v1.2
   nodes:
   - 10.219.196.145
-  - 10.219.196.150
   - 10.219.192.90
+  - 10.219.196.150
   dataDirHostPath: "/curvebs/data"
   logDirHostPath: "/curvebs/log"
   etcd:
-    port: 23900
-    listenPort: 23910
+    port: 23820
+    listenPort: 23830

--- a/delete-resource.sh
+++ b/delete-resource.sh
@@ -4,4 +4,5 @@ kubectl delete cm curve-etcd-config-c -n curvebs
 kubectl delete deploy curve-etcd-a -n curvebs
 kubectl delete deploy curve-etcd-b -n curvebs
 kubectl delete deploy curve-etcd-c -n curvebs
+kubectl delete --all -n curvebs
 kubectl delete -f config/samples/


### PR DESCRIPTION
This pr fix the issue that the etcd pod number(nodename) and hostpath directory is mismatch if we delete all etcd pod and recreate it. Because nodeNameIP map is unordered and client-go list all nodes also is not ordered. 